### PR TITLE
Bugfixes + mzML IO placeholder

### DIFF
--- a/src/evaluate.py
+++ b/src/evaluate.py
@@ -19,11 +19,11 @@ logger = logging.getLogger('cluster_representative')
                     'cluster members')
 @click.option('--filename_spectra', 'filename_spectra',
               type=click.Path(dir_okay=False),
-              help='Input MGF file containing original spectra (including '
-                   'cluster assignments)')
+              help='Input spectrum file containing original spectra'
+                   '(including cluster assignments)')
 @click.option('--filename_representatives', 'filename_representatives',
               type=click.Path(dir_okay=False),
-              help='Input MGF file containing cluster representatives')
+              help='Input spectrum file containing cluster representatives')
 @click.option('--filename_out', 'filename_out',
               type=click.Path(dir_okay=False),
               help='Output CSV file containing representative scores')
@@ -51,10 +51,10 @@ def evaluate(filename_spectra: str, filename_representatives: str,
     Parameters
     ----------
     filename_spectra : str
-        Input MGF file containing original spectra (including cluster
+        Input spectrum file containing original spectra (including cluster
         assignments).
     filename_representatives : str
-        Input MGF file containing cluster representatives.
+        Input spectrum file containing cluster representatives.
     filename_out : str
         Output JSON file containing representative scores.
     measures : Tuple[str]

--- a/src/evaluate.py
+++ b/src/evaluate.py
@@ -85,19 +85,20 @@ def evaluate(filename_spectra: str, filename_representatives: str,
                 filename_spectra)
     spectra = {f'{spectrum.filename}:scan:{spectrum.scan}': spectrum
                for spectrum in ms_io.read_spectra(filename_spectra)}
-    if measures == 'fraction_by':
-        logger.info('Assign peptide identifications from file %s to the '
-                    'cluster representatives', filename_psm)
-        psms = ms_io.read_psms(filename_psm)
-        for spectra_ref, sequence in psms['sequence'].items():
-            if spectra_ref in spectra:
-                spectra[spectra_ref].peptide = sequence
 
     logger.info('Read cluster representatives from spectrum file %s',
                 filename_representatives)
     representatives = {
         spectrum.cluster: spectrum
         for spectrum in ms_io.read_spectra(filename_representatives)}
+    if 'fraction_by' in measures:
+        logger.info('Assign peptide identifications from file %s to the '
+                    'cluster representatives', filename_psm)
+        psms = ms_io.read_psms(filename_psm)
+        for spectra_ref, sequence in tqdm.tqdm(
+                psms['sequence'].items(), desc='PSMs assigned', unit='PSMs'):
+            if spectra_ref in representatives:
+                representatives[spectra_ref].peptide = sequence
 
     logger.info('Evaluate cluster representatives')
     cluster_keys = []

--- a/src/ms_io.py
+++ b/src/ms_io.py
@@ -509,7 +509,8 @@ def _read_psms_idxml(filename: str) -> pd.DataFrame:
         protein_ids[0].getMetaValue('spectra_data')[0].decode()))[0]
     for psm in tqdm.tqdm(psms, desc='PSMs read', unit='PSMs'):
         spectrum_index = psm.getMetaValue('spectrum_reference').decode()
-        scans.append(int(spectrum_index[spectrum_index.find('=') + 1:]))
+        scans.append(
+            int(spectrum_index[spectrum_index.find('scan=') + len('scan='):]))
         sequences.append(psm.getHits()[0].getSequence().toString().decode())
         scores.append(psm.getHits()[0].getScore())
     psms = pd.DataFrame({'filename': peak_filename, 'scan': scans,

--- a/src/ms_io.py
+++ b/src/ms_io.py
@@ -73,8 +73,8 @@ def _read_spectra_mgf(filename: str) -> Iterable[sus.MsmsSpectrum]:
             spectrum_dict['params'].get('rtinseconds'))
         spectrum.filename = spectrum_dict['params'].get(
             'filename', os.path.splitext(os.path.basename(filename))[0])
-        if 'scans' in spectrum_dict['params']:
-            spectrum.scan = spectrum_dict['params']['scans']
+        if 'scan' in spectrum_dict['params']:
+            spectrum.scan = spectrum_dict['params']['scan']
         if 'cluster' in spectrum_dict['params']:
             spectrum.cluster = spectrum_dict['params']['cluster']
         yield spectrum
@@ -337,7 +337,7 @@ def write_spectra(filename: str, spectra: Iterable[sus.MsmsSpectrum]) -> None:
     """
     Write the given spectra to a peak file.
 
-    Supported formats: MGF, mzML, mzXML.
+    Supported formats: MGF, mzML.
 
     Parameters
     ----------
@@ -348,9 +348,9 @@ def write_spectra(filename: str, spectra: Iterable[sus.MsmsSpectrum]) -> None:
     """
     ext = os.path.splitext(filename.lower())[1]
     if ext == '.mgf':
-        yield from _write_spectra_mgf(filename, spectra)
+        _write_spectra_mgf(filename, spectra)
     elif ext == '.mzml':
-        yield from _write_spectra_mzml(filename, spectra)
+        _write_spectra_mzml(filename, spectra)
     else:
         logger.error('Unsupported peak file format (supported formats: MGF, '
                      'mzML)')
@@ -398,7 +398,7 @@ def _spectra_to_dicts(spectra: Iterable[sus.MsmsSpectrum]) -> Iterable[Dict]:
         if hasattr(spectrum, 'filename'):
             params['filename'] = spectrum.filename
         if hasattr(spectrum, 'scan'):
-            params['scans'] = spectrum.scan
+            params['scan'] = spectrum.scan
         if hasattr(spectrum, 'cluster'):
             params['cluster'] = spectrum.cluster
         yield {'params': params,

--- a/src/ms_io.py
+++ b/src/ms_io.py
@@ -335,6 +335,32 @@ def _convert_clusters_mscluster(clusters: Dict[int, int],
 
 def write_spectra(filename: str, spectra: Iterable[sus.MsmsSpectrum]) -> None:
     """
+    Write the given spectra to a peak file.
+
+    Supported formats: MGF, mzML, mzXML.
+
+    Parameters
+    ----------
+    filename : str
+        The file name where the spectra will be written.
+    spectra : Iterable[sus.MsmsSpectrum]
+        The spectra to be written to the peak file.
+    """
+    ext = os.path.splitext(filename.lower())[1]
+    if ext == '.mgf':
+        yield from _write_spectra_mgf(filename, spectra)
+    elif ext == '.mzml':
+        yield from _write_spectra_mzml(filename, spectra)
+    else:
+        logger.error('Unsupported peak file format (supported formats: MGF, '
+                     'mzML)')
+        raise ValueError('Unsupported peak file format (supported formats: '
+                         'MGF, mzML)')
+
+
+def _write_spectra_mgf(filename: str, spectra: Iterable[sus.MsmsSpectrum]) \
+        -> None:
+    """
     Write the given spectra to an MGF file.
 
     Parameters
@@ -378,6 +404,21 @@ def _spectra_to_dicts(spectra: Iterable[sus.MsmsSpectrum]) -> Iterable[Dict]:
         yield {'params': params,
                'm/z array': spectrum.mz,
                'intensity array': spectrum.intensity}
+
+
+def _write_spectra_mzml(filename: str, spectra: Iterable[sus.MsmsSpectrum]) \
+        -> None:
+    """
+    Write the given spectra to an mzML file.
+
+    Parameters
+    ----------
+    filename : str
+        The mzML file name where the spectra will be written.
+    spectra : Iterable[sus.MsmsSpectrum]
+        The spectra to be written to the mzML file.
+    """
+    raise NotImplementedError('mzML export is not supported yet')
 
 
 ###############################################################################

--- a/src/representative.py
+++ b/src/representative.py
@@ -38,14 +38,14 @@ def get_cluster_spectra(spectra: Dict[str, sus.MsmsSpectrum]) \
 
 
 @click.command('representative',
-               help='Export representative spectra for each cluster to MGF')
+               help='Export representative spectra for each cluster')
 @click.option('--filename_in', 'filename_in',
               type=click.Path(exists=True, dir_okay=False),
-              help='Input MGF file containing cluster assignments')
+              help='Input spectrum file containing cluster assignments')
 @click.option('--filename_out', 'filename_out',
               type=click.Path(dir_okay=False),
-              help='Output MGF file containing representative spectra for each'
-                   ' cluster')
+              help='Output spectrum file containing representative spectra for'
+                   ' each cluster')
 @click.option('--representative_method', 'representative_method',
               type=click.Choice(['most_similar', 'best_spectrum', 'bin']),
               help='Method used to select the representative spectrum for each'
@@ -61,7 +61,7 @@ def get_cluster_spectra(spectra: Dict[str, sus.MsmsSpectrum]) \
               help='Input PSM file (optional; supported formats: mzTab, '
                    'mzIdentML, JSON, MaxQuant; required for the '
                    '"best_spectrum" method)')
-@click.option('--higher_is_better', 'higher_is_better', type=bool,
+@click.option('--higher_is_better/--lower_is_better', 'higher_is_better',
               default=True, show_default=True,
               help='Flag indicating whether higher PSM scores are better or '
                    'not')
@@ -112,9 +112,9 @@ def representative(filename_in: str, filename_out: str,
     Parameters
     ----------
     filename_in : str
-        Input MGF file containing cluster assignments.
+        Input spectrum file containing cluster assignments.
     filename_out : str
-        Output MGF file containing representative spectra for each cluster.
+        Output spectrum file containing representative spectra for each cluster.
     representative_method : str
         Method used to select the representative spectrum for each cluster
         (options: "best_spectrum", "most_similar", "bin").
@@ -187,7 +187,7 @@ def representative(filename_in: str, filename_out: str,
             #                cluster_key)
             pass
 
-    logger.info('Export %d cluster representatives to MGF file %s',
+    logger.info('Export %d cluster representatives to spectrum file %s',
                 len(cluster_representatives), filename_out)
     ms_io.write_spectra(filename_out, cluster_representatives)
 

--- a/src/spectra_add_cluster.py
+++ b/src/spectra_add_cluster.py
@@ -12,16 +12,16 @@ logger = logging.getLogger('cluster_representative')
 @click.command('spectra_add_cluster',
                help='Export spectra to an MGF file containing cluster '
                     'assignments')
-@click.option('--spectra', '-s', 'filename_spectra',
-              help='Input spectrum file (supported file formats:    MGF, mzML, '
+@click.option('--spectra', 'filename_spectra',
+              help='Input spectrum file (supported file formats: MGF, mzML, '
                    'mzXML)',
               required=True)
-@click.option('--cluster', '-c', 'filename_cluster', nargs=2,
+@click.option('--cluster', 'filename_cluster', nargs=2,
               help='Input cluster assignments and cluster type (supported '
                    'clustering formats: MaRaCluster, spectra-cluster, '
                    'MS-Cluster)',
               required=True)
-@click.option('--out', '-o', 'filename_out',
+@click.option('--out', 'filename_out',
               help='Output MGF file containing the updated spectra with '
                    'associated cluster assignments',
               required=True)

--- a/src/spectra_add_cluster.py
+++ b/src/spectra_add_cluster.py
@@ -22,8 +22,8 @@ logger = logging.getLogger('cluster_representative')
                    'MS-Cluster)',
               required=True)
 @click.option('--out', 'filename_out',
-              help='Output MGF file containing the updated spectra with '
-                   'associated cluster assignments',
+              help='Output mzML or MGF file containing the updated spectra '
+                   'with associated cluster assignments',
               required=True)
 def spectra_add_cluster(filename_spectra: str,
                         filename_cluster: Tuple[str, str],
@@ -43,8 +43,8 @@ def spectra_add_cluster(filename_spectra: str,
         else:
             logger.warning('No cluster assignment found for spectrum %s',
                            spectrum.identifier)
-    logging.info('Export the spectra including cluster assignments to MGF file'
-                 ' %s', filename_out)
+    logging.info('Export the spectra including cluster assignments to spectrum'
+                 ' file %s', filename_out)
     # Make sure the exported spectra are grouped by their clusters.
     ms_io.write_spectra(filename_out, sorted(
         spectra.values(), key=lambda spectrum: (spectrum.cluster,


### PR DESCRIPTION
Placeholder for exporting to mzML. This functionality should be completed in the `ms_io._write_spectra_mzml` method.

Non-standard information that has to be associated with each spectrum (see for example the `_write_spectra_mgf` method):

- The cluster identifier.
- The original scan number. Currently the `_read_spectra_mzml` extracts the scan number from the spectrum title, but the title format is different for cluster representatives. I think the best option will be to store the original scan number as a metadata element. This will also need to be handled properly when reading the mzML in `_read_spectra_mzml`.

---

Run the different scripts as follows:

1. Assign cluster identifiers to the spectra.

```python spectra_add_cluster.py --spectra 01650b_BA5-TUM_first_pool_75_01_01-3xHCD-1h-R2.mzML --cluster MaRaCluster.clusters_p10.tsv maracluster --out clusters.mgf```

2. Extract cluster representatives using one of the different methods.

```python representative.py --filename_in clusters.mgf --filename_out representative.mgf --representative_method best_spectrum --filename_psm 01650b_BA5-TUM_first_pool_75_01_01-3xHCD-1h-R2-features-index-percolator-fdr-filter.idXML --lower_is_better```

3. Evaluate the cluster representatives.

```python evaluate.py --filename_spectra clusters.mgf --filename_representatives representative.mgf --filename_out out.csv --measure avg_dot --measure fraction_by --filename_psm non_existing_representative_ids.idXML```